### PR TITLE
Fix for error without type or message.

### DIFF
--- a/src/Provider/Mollie.php
+++ b/src/Provider/Mollie.php
@@ -99,7 +99,11 @@ class Mollie extends AbstractProvider
 		{
 			if (isset($data['error']))
 			{
-				$message = sprintf('[%s] %s', $data['error']['type'], $data['error']['message']);
+				if (isset($data['error']['type']) && isset($data['error']['message'])) {
+					$message = sprintf('[%s] %s', $data['error']['type'], $data['error']['message']);
+				} else {
+					$message = $data['error'];
+				}
 
 				if (isset($data['error']['field']))
 				{


### PR DESCRIPTION
At least the 'invalid_grant' error is sent without type/message, this fix makes sure there is no undefined index error.
