### PR TITLE
Move to league/oauth2-client ^2.0 and PHP >= 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
 - 7.1
 - hhvm
 
+dist: trusty
 sudo: false
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+- 5.5
 - 5.6
 - 7.0
 - 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-- 5.5
 - 5.6
 - 7.0
+- 7.1
 - hhvm
 
 sudo: false

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Use Mollie Connect (OAuth) to easily connect Mollie Merchant accounts to your ap
 
 By far the easiest way to install the Mollie API client is to require it with [Composer](http://getcomposer.org/doc/00-intro.md).
 
-	$ composer require mollie/oauth2-mollie-php ~1.0
+	$ composer require mollie/oauth2-mollie-php ^1.0
 
 	    {
 	        "require": {
-	            "mollie/oauth2-mollie-php": "~1.0"
+	            "mollie/oauth2-mollie-php": "^1.0"
 	        }
 	    }
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "league/oauth2-client": "^2.0"
+        "league/oauth2-client": "^1.0 || ^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.7",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
       "refunds", "api", "payments", "gateway"
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=5.6.0",
         "league/oauth2-client": "^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
       "refunds", "api", "payments", "gateway"
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=5.5.0",
         "league/oauth2-client": "^1.0 || ^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "league/oauth2-client": "^1.0"
+        "league/oauth2-client": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.7",


### PR DESCRIPTION
PHP 5.5 is now deprecated, and some packages (e.g. Stripe's OAuth library) play together nicely if we refer to oauth-client ^2.0

(tested to work under php 7.1)