### PR TITLE
Assert that the clientId starts with the expected token

### DIFF
--- a/src/Provider/Mollie.php
+++ b/src/Provider/Mollie.php
@@ -26,6 +26,13 @@ class Mollie extends AbstractProvider
 	const MOLLIE_WEB_URL = 'https://www.mollie.com';
 
 	/**
+	 * The prefix for the Client ID
+	 *
+	 * @const string
+	 */
+	const CLIENT_ID_PREFIX = 'app_';
+
+	/**
 	 * Shortcuts to the available Mollie scopes.
 	 *
 	 * In order to access the Mollie API endpoints on behalf of your app user, your
@@ -55,6 +62,15 @@ class Mollie extends AbstractProvider
 	const SCOPE_ORGANIZATIONS_WRITE = 'organizations.write';
 	const SCOPE_ONBOARDING_READ     = 'onboarding.read';
 	const SCOPE_ONBOARDING_WRITE    = 'onboarding.write';
+
+	public function __construct(array $options = [], array $collaborators = [])
+	{
+		parent::__construct($options, $collaborators);
+
+		if (!isset($options["clientId"]) && strpos($options["clientId"], self::CLIENT_ID_PREFIX) === 0) {
+			throw new \DomainException("Mollie needs the client ID to be prefixed with " . self::CLIENT_ID_PREFIX . ".");
+		}
+	}
 
 	/**
 	 * Returns the base URL for authorizing a client.

--- a/src/Provider/Mollie.php
+++ b/src/Provider/Mollie.php
@@ -67,7 +67,7 @@ class Mollie extends AbstractProvider
 	{
 		parent::__construct($options, $collaborators);
 
-		if (isset($options["clientId"]) && strpos($options["clientId"], self::CLIENT_ID_PREFIX) === 0) {
+		if (isset($options["clientId"]) && strpos($options["clientId"], self::CLIENT_ID_PREFIX) !== 0) {
 			throw new \DomainException("Mollie needs the client ID to be prefixed with " . self::CLIENT_ID_PREFIX . ".");
 		}
 	}

--- a/src/Provider/Mollie.php
+++ b/src/Provider/Mollie.php
@@ -67,7 +67,7 @@ class Mollie extends AbstractProvider
 	{
 		parent::__construct($options, $collaborators);
 
-		if (!isset($options["clientId"]) && strpos($options["clientId"], self::CLIENT_ID_PREFIX) === 0) {
+		if (isset($options["clientId"]) && strpos($options["clientId"], self::CLIENT_ID_PREFIX) === 0) {
 			throw new \DomainException("Mollie needs the client ID to be prefixed with " . self::CLIENT_ID_PREFIX . ".");
 		}
 	}

--- a/tests/src/Provider/MollieTest.php
+++ b/tests/src/Provider/MollieTest.php
@@ -1,6 +1,7 @@
 <?php namespace Mollie\OAuth2\Client\Test\Provider;
 
 use Mockery as m;
+use Mollie\OAuth2\Client\Provider\Mollie;
 
 class MollieTest extends \PHPUnit_Framework_TestCase
 {
@@ -8,8 +9,8 @@ class MollieTest extends \PHPUnit_Framework_TestCase
 
 	protected function setUp ()
 	{
-		$this->provider = new \Mollie\OAuth2\Client\Provider\Mollie([
-			'clientId'     => 'mock_client_id',
+		$this->provider = new Mollie([
+			'clientId'     => 'app_mock_client_id',
 			'clientSecret' => 'mock_secret',
 			'redirectUri'  => 'none',
 		]);
@@ -19,6 +20,18 @@ class MollieTest extends \PHPUnit_Framework_TestCase
     {
         m::close();
         parent::tearDown();
+    }
+
+    public function testClientIdShouldThrowExceptionWhenNotPrefixed()
+    {
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage("Mollie needs the client ID to be prefixed with " . Mollie::CLIENT_ID_PREFIX . ".");
+
+        $provider = new \Mollie\OAuth2\Client\Provider\Mollie([
+            'clientId'     => 'not_pefixed_client_id',
+            'clientSecret' => 'mock_secret',
+            'redirectUri'  => 'none',
+        ]);
     }
 
     public function testGetBaseAccessTokenUrl()


### PR DESCRIPTION
When constructing the authorize URL the Mollie oAuth server will accept a clientId without the "app_" prefix.

However when u implement the generate token with an clientId which is not prefixed you will get an exception with just the message "grant_type". When you debug you find out that Mollie is giving an error about the invalidity of the client.

This is due to the token in the server (with prefix) and the one we send (without). 

app_12345 === 12345

This is kinda hard to debug and find out, that's why i created this PR to do a domain assertion on the clientId to prevent this from happening.