### PR TITLE
Endpoints setters

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,6 +10,11 @@
          stopOnFailure="false"
          syntaxCheck="false"
 >
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
     <testsuites>
         <testsuite name="Package Test Suite">
             <directory suffix=".php">./tests/</directory>

--- a/src/Provider/Mollie.php
+++ b/src/Provider/Mollie.php
@@ -57,6 +57,42 @@ class Mollie extends AbstractProvider
 	const SCOPE_ONBOARDING_WRITE    = 'onboarding.write';
 
 	/**
+     * @var string
+     */
+	private $mollieApiUrl = self::MOLLIE_API_URL;
+
+	/**
+     * @var string
+     */
+    private $mollieWebUrl = self::MOLLIE_WEB_URL;
+
+    /**
+     * Define Mollie api URL
+     *
+     * @param string $url
+     * @return Mollie
+     */
+    public function setMollieApiUrl ($url)
+    {
+        $this->mollieApiUrl = $url;
+
+        return $this;
+    }
+
+    /**
+     * Define Mollie web URL
+     *
+     * @param string $url
+     * @return Mollie
+     */
+    public function setMollieWebUrl ($url)
+    {
+        $this->mollieWebUrl = $url;
+
+        return $this;
+    }
+
+	/**
 	 * Returns the base URL for authorizing a client.
 	 *
 	 * Eg. https://oauth.service.com/authorize
@@ -65,7 +101,7 @@ class Mollie extends AbstractProvider
 	 */
 	public function getBaseAuthorizationUrl ()
 	{
-		return static::MOLLIE_WEB_URL . '/oauth2/authorize';
+		return $this->mollieWebUrl . '/oauth2/authorize';
 	}
 
 	/**
@@ -78,7 +114,7 @@ class Mollie extends AbstractProvider
 	 */
 	public function getBaseAccessTokenUrl (array $params)
 	{
-		return static::MOLLIE_API_URL . '/oauth2/tokens';
+		return $this->mollieApiUrl . '/oauth2/tokens';
 	}
 
 	/**

--- a/src/Provider/Mollie.php
+++ b/src/Provider/Mollie.php
@@ -57,40 +57,40 @@ class Mollie extends AbstractProvider
 	const SCOPE_ONBOARDING_WRITE    = 'onboarding.write';
 
 	/**
-     * @var string
-     */
+	 * @var string
+	 */
 	private $mollieApiUrl = self::MOLLIE_API_URL;
 
 	/**
-     * @var string
-     */
-    private $mollieWebUrl = self::MOLLIE_WEB_URL;
+	 * @var string
+	 */
+	private $mollieWebUrl = self::MOLLIE_WEB_URL;
 
-    /**
-     * Define Mollie api URL
-     *
-     * @param string $url
-     * @return Mollie
-     */
-    public function setMollieApiUrl ($url)
-    {
-        $this->mollieApiUrl = $url;
+	/**
+	 * Define Mollie api URL
+	 *
+	 * @param string $url
+	 * @return Mollie
+	 */
+	public function setMollieApiUrl ($url)
+	{
+		$this->mollieApiUrl = $url;
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Define Mollie web URL
-     *
-     * @param string $url
-     * @return Mollie
-     */
-    public function setMollieWebUrl ($url)
-    {
-        $this->mollieWebUrl = $url;
+	/**
+	 * Define Mollie web URL
+	 *
+	 * @param string $url
+	 * @return Mollie
+	 */
+	public function setMollieWebUrl ($url)
+	{
+		$this->mollieWebUrl = $url;
 
-        return $this;
-    }
+		return $this;
+	}
 
 	/**
 	 * Returns the base URL for authorizing a client.

--- a/src/Provider/Mollie.php
+++ b/src/Provider/Mollie.php
@@ -63,6 +63,16 @@ class Mollie extends AbstractProvider
 	const SCOPE_ONBOARDING_READ     = 'onboarding.read';
 	const SCOPE_ONBOARDING_WRITE    = 'onboarding.write';
 
+    /**
+     * @var string
+     */
+    private $mollieApiUrl;
+
+    /**
+     * @var string
+     */
+    private $mollieWebUrl;
+
 	public function __construct(array $options = [], array $collaborators = [])
 	{
 		if (isset($options["clientId"]) && strpos($options["clientId"], self::CLIENT_ID_PREFIX) !== 0) {
@@ -75,16 +85,6 @@ class Mollie extends AbstractProvider
 
 		parent::__construct($options, $collaborators);
 	}
-
-	/**
-	 * @var string
-	 */
-	private $mollieApiUrl;
-
-	/**
-	 * @var string
-	 */
-	private $mollieWebUrl;
 
 	/**
 	 * Returns the base URL for authorizing a client.

--- a/src/Provider/Mollie.php
+++ b/src/Provider/Mollie.php
@@ -66,25 +66,47 @@ class Mollie extends AbstractProvider
     /**
      * @var string
      */
-    private $mollieApiUrl;
+    private $mollieApiUrl = self::MOLLIE_API_URL;
 
     /**
      * @var string
      */
-    private $mollieWebUrl;
+    private $mollieWebUrl = self::MOLLIE_WEB_URL;
 
 	public function __construct(array $options = [], array $collaborators = [])
 	{
+        parent::__construct($options, $collaborators);
+
 		if (isset($options["clientId"]) && strpos($options["clientId"], self::CLIENT_ID_PREFIX) !== 0) {
 			throw new \DomainException("Mollie needs the client ID to be prefixed with " . self::CLIENT_ID_PREFIX . ".");
 		}
-
-		$this->mollieApiUrl = (isset($options['mollieApiUrl']) ? $options['mollieApiUrl'] : null) ?: self::MOLLIE_API_URL;
-		$this->mollieWebUrl = (isset($options['mollieWebUrl']) ? $options['mollieWebUrl'] : null) ?: self::MOLLIE_WEB_URL;
-		unset($options['mollieApiUrl'], $options['mollieWebUrl']);
-
-		parent::__construct($options, $collaborators);
 	}
+
+    /**
+     * Define Mollie api URL
+     *
+     * @param string $url
+     * @return Mollie
+     */
+    public function setMollieApiUrl ($url)
+    {
+        $this->mollieApiUrl = $url;
+
+        return $this;
+    }
+
+    /**
+     * Define Mollie web URL
+     *
+     * @param string $url
+     * @return Mollie
+     */
+    public function setMollieWebUrl ($url)
+    {
+        $this->mollieWebUrl = $url;
+
+        return $this;
+    }
 
 	/**
 	 * Returns the base URL for authorizing a client.

--- a/src/Provider/Mollie.php
+++ b/src/Provider/Mollie.php
@@ -65,48 +65,26 @@ class Mollie extends AbstractProvider
 
 	public function __construct(array $options = [], array $collaborators = [])
 	{
-		parent::__construct($options, $collaborators);
-
 		if (isset($options["clientId"]) && strpos($options["clientId"], self::CLIENT_ID_PREFIX) !== 0) {
 			throw new \DomainException("Mollie needs the client ID to be prefixed with " . self::CLIENT_ID_PREFIX . ".");
 		}
+
+		$this->mollieApiUrl = (isset($options['mollieApiUrl']) ? $options['mollieApiUrl'] : null) ?: self::MOLLIE_API_URL;
+		$this->mollieWebUrl = (isset($options['mollieWebUrl']) ? $options['mollieWebUrl'] : null) ?: self::MOLLIE_WEB_URL;
+		unset($options['mollieApiUrl'], $options['mollieWebUrl']);
+
+		parent::__construct($options, $collaborators);
 	}
 
 	/**
 	 * @var string
 	 */
-	private $mollieApiUrl = self::MOLLIE_API_URL;
+	private $mollieApiUrl;
 
 	/**
 	 * @var string
 	 */
-	private $mollieWebUrl = self::MOLLIE_WEB_URL;
-
-	/**
-	 * Define Mollie api URL
-	 *
-	 * @param string $url
-	 * @return Mollie
-	 */
-	public function setMollieApiUrl ($url)
-	{
-		$this->mollieApiUrl = $url;
-
-		return $this;
-	}
-
-	/**
-	 * Define Mollie web URL
-	 *
-	 * @param string $url
-	 * @return Mollie
-	 */
-	public function setMollieWebUrl ($url)
-	{
-		$this->mollieWebUrl = $url;
-
-		return $this;
-	}
+	private $mollieWebUrl;
 
 	/**
 	 * Returns the base URL for authorizing a client.

--- a/tests/src/Provider/MollieTest.php
+++ b/tests/src/Provider/MollieTest.php
@@ -217,20 +217,16 @@ class MollieTest extends \PHPUnit_Framework_TestCase
 
     public function testWhenDefiningADifferentMollieApiUrlThenUseThisOnApiCalls()
     {
-        $options = array_merge(['mollieApiUrl' => 'https://api.mollie.nl'], self::OPTIONS);
+        $this->provider->setMollieApiUrl('https://api.mollie.nl');
 
-        $provider = new Mollie($options);
-
-        $this->assertEquals('https://api.mollie.nl/oauth2/tokens', $provider->getBaseAccessTokenUrl([]));
+        $this->assertEquals('https://api.mollie.nl/oauth2/tokens', $this->provider->getBaseAccessTokenUrl([]));
     }
 
     public function testWhenDefiningADifferentMollieWebUrlThenUseThisForAuthorize()
     {
-        $options = array_merge(['mollieWebUrl' => 'https://www.mollie.nl'], self::OPTIONS);
+        $this->provider->setMollieWebUrl('https://www.mollie.nl');
 
-        $provider = new Mollie($options);
-
-        list($url) = explode('?', $provider->getAuthorizationUrl());
+        list($url) = explode('?', $this->provider->getAuthorizationUrl());
         $this->assertEquals('https://www.mollie.nl/oauth2/authorize', $url);
     }
 }

--- a/tests/src/Provider/MollieTest.php
+++ b/tests/src/Provider/MollieTest.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\ResponseInterface;
 
 class MollieTest extends \PHPUnit_Framework_TestCase
 {
-    const MOCK_CLIENT_ID = 'mock_client_id';
+    const MOCK_CLIENT_ID = 'app_mock_client_id';
     const MOCK_SECRET = 'mock_secret';
     const REDIRECT_URI = 'none';
 
@@ -215,7 +215,7 @@ class MollieTest extends \PHPUnit_Framework_TestCase
 
     public function testWhenDefiningADifferentMollieApiUrlThenUseThisOnApiCalls()
     {
-        $provider = new Mollie(['clientId' => '', 'clientSecret' => '', 'redirectUri' => '']);
+        $provider = new Mollie(['clientId' => self::MOCK_CLIENT_ID, 'clientSecret' => '', 'redirectUri' => '']);
 
         $provider->setMollieApiUrl('https://api.mollie.nl');
 
@@ -224,7 +224,7 @@ class MollieTest extends \PHPUnit_Framework_TestCase
 
     public function testWhenDefiningADifferentMollieWebUrlThenUseThisForAuthorize()
     {
-        $provider = new Mollie(['clientId' => '', 'clientSecret' => '', 'redirectUri' => '']);
+        $provider = new Mollie(['clientId' => self::MOCK_CLIENT_ID, 'clientSecret' => '', 'redirectUri' => '']);
 
         $provider->setMollieWebUrl('https://www.mollie.nl');
 

--- a/tests/src/Provider/MollieTest.php
+++ b/tests/src/Provider/MollieTest.php
@@ -13,15 +13,17 @@ class MollieTest extends \PHPUnit_Framework_TestCase
     const MOCK_SECRET = 'mock_secret';
     const REDIRECT_URI = 'none';
 
+    const OPTIONS = [
+        'clientId' => self::MOCK_CLIENT_ID,
+        'clientSecret' => self::MOCK_SECRET,
+        'redirectUri' => self::REDIRECT_URI,
+    ];
+
     protected $provider;
 
     protected function setUp()
     {
-        $this->provider = new Mollie([
-            'clientId' => self::MOCK_CLIENT_ID,
-            'clientSecret' => self::MOCK_SECRET,
-            'redirectUri' => self::REDIRECT_URI,
-        ]);
+        $this->provider = new Mollie(self::OPTIONS);
     }
 
     public function tearDown()
@@ -35,7 +37,7 @@ class MollieTest extends \PHPUnit_Framework_TestCase
         $this->expectException(\DomainException::class);
         $this->expectExceptionMessage("Mollie needs the client ID to be prefixed with " . Mollie::CLIENT_ID_PREFIX . ".");
 
-        $provider = new \Mollie\OAuth2\Client\Provider\Mollie([
+        new Mollie([
             'clientId'     => 'not_pefixed_client_id',
             'clientSecret' => 'mock_secret',
             'redirectUri'  => 'none',
@@ -215,18 +217,18 @@ class MollieTest extends \PHPUnit_Framework_TestCase
 
     public function testWhenDefiningADifferentMollieApiUrlThenUseThisOnApiCalls()
     {
-        $provider = new Mollie(['clientId' => self::MOCK_CLIENT_ID, 'clientSecret' => '', 'redirectUri' => '']);
+        $options = array_merge(['mollieApiUrl' => 'https://api.mollie.nl'], self::OPTIONS);
 
-        $provider->setMollieApiUrl('https://api.mollie.nl');
+        $provider = new Mollie($options);
 
         $this->assertEquals('https://api.mollie.nl/oauth2/tokens', $provider->getBaseAccessTokenUrl([]));
     }
 
     public function testWhenDefiningADifferentMollieWebUrlThenUseThisForAuthorize()
     {
-        $provider = new Mollie(['clientId' => self::MOCK_CLIENT_ID, 'clientSecret' => '', 'redirectUri' => '']);
+        $options = array_merge(['mollieWebUrl' => 'https://www.mollie.nl'], self::OPTIONS);
 
-        $provider->setMollieWebUrl('https://www.mollie.nl');
+        $provider = new Mollie($options);
 
         list($url) = explode('?', $provider->getAuthorizationUrl());
         $this->assertEquals('https://www.mollie.nl/oauth2/authorize', $url);


### PR DESCRIPTION
In order to make easier to switch between development, staging and production environment this changes provide a way to setup de URLs on the project which requires it, this values are not mandatory and production values are set as default