### PR TITLE
Revoke tokens

### DIFF
--- a/src/Provider/Mollie.php
+++ b/src/Provider/Mollie.php
@@ -149,17 +149,33 @@ class Mollie extends AbstractProvider
 		return static::MOLLIE_API_URL . '/v2/organizations/me';
 	}
 
+    /**
+     * @param $accessToken
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
     public function revokeAccessToken($accessToken)
     {
         $this->revokeToken('access_token', $accessToken);
     }
 
+    /**
+     * @param $refreshToken
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
     public function revokeRefreshToken($refreshToken)
     {
         $this->revokeToken('refresh_token', $refreshToken);
     }
 
-	public function revokeToken($type, $token)
+    /**
+     * @param $type
+     * @param $token
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
+    public function revokeToken($type, $token)
     {
         $this->getRevokeTokenResponse([
             'token_type_hint' => $type,
@@ -167,27 +183,28 @@ class Mollie extends AbstractProvider
         ]);
 	}
 
+    /**
+     * @param array $params
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     */
     protected function getRevokeTokenResponse(array $params)
     {
-        $query = $this->buildQueryString($params);
-        $url = $this->appendQuery(
-            $this->getBaseAccessTokenUrl([]),
-            $query
-        );
-
-        $options['headers'] = [
-            'client_id' => $this->clientId,
+        array_push($params, [
+            'client_id'     => $this->clientId,
             'client_secret' => $this->clientSecret,
-        ];
+            'redirect_uri'  => $this->redirectUri,
+        ]);
 
-        $request = $this->getAuthenticatedRequest(
+        $options = ['headers' => ['content-type' => 'application/x-www-form-urlencoded']];
+        $options['body'] = $this->buildQueryString($params);
+
+        $request = $this->getRequest(
             self::METHOD_DELETE,
-            $url,
-            null,
+            $this->getBaseAccessTokenUrl([]),
             $options
         );
-
-        var_dump($request->getHeaders());
 
         return $this->getHttpClient()->send($request);
 	}

--- a/src/Provider/Mollie.php
+++ b/src/Provider/Mollie.php
@@ -175,11 +175,19 @@ class Mollie extends AbstractProvider
             $query
         );
 
+        $options['headers'] = [
+            'client_id' => $this->clientId,
+            'client_secret' => $this->clientSecret,
+        ];
+
         $request = $this->getAuthenticatedRequest(
             self::METHOD_DELETE,
             $url,
-            ''
+            null,
+            $options
         );
+
+        var_dump($request->getHeaders());
 
         return $this->getHttpClient()->send($request);
 	}

--- a/src/Provider/Mollie.php
+++ b/src/Provider/Mollie.php
@@ -37,6 +37,16 @@ class Mollie extends AbstractProvider
      */
     const METHOD_DELETE = 'DELETE';
 
+    /**
+     * @var string Token type hint for Mollie access tokens.
+     */
+    const TOKEN_TYPE_ACCESS = 'access_token';
+
+    /**
+     * @var string Token type hint for Mollie refresh tokens.
+     */
+    const TOKEN_TYPE_REFRESH = 'refresh_token';
+
 	/**
 	 * Shortcuts to the available Mollie scopes.
 	 *
@@ -159,7 +169,7 @@ class Mollie extends AbstractProvider
      */
     public function revokeAccessToken($accessToken)
     {
-        return $this->revokeToken('access_token', $accessToken);
+        return $this->revokeToken(self::TOKEN_TYPE_ACCESS, $accessToken);
     }
 
     /**
@@ -172,7 +182,7 @@ class Mollie extends AbstractProvider
      */
     public function revokeRefreshToken($refreshToken)
     {
-        return $this->revokeToken('refresh_token', $refreshToken);
+        return $this->revokeToken(self::TOKEN_TYPE_REFRESH, $refreshToken);
     }
 
     /**

--- a/src/Provider/Mollie.php
+++ b/src/Provider/Mollie.php
@@ -191,11 +191,9 @@ class Mollie extends AbstractProvider
      */
     protected function getRevokeTokenResponse(array $params)
     {
-        array_push($params, [
-            'client_id'     => $this->clientId,
-            'client_secret' => $this->clientSecret,
-            'redirect_uri'  => $this->redirectUri,
-        ]);
+        $params['client_id'] = $this->clientId;
+        $params['client_secret'] = $this->clientSecret;
+        $params['redirect_uri'] = $this->redirectUri;
 
         $options = ['headers' => ['content-type' => 'application/x-www-form-urlencoded']];
         $options['body'] = $this->buildQueryString($params);

--- a/src/Provider/Mollie.php
+++ b/src/Provider/Mollie.php
@@ -126,7 +126,7 @@ class Mollie extends AbstractProvider
 	}
 
 	/**
-	 * Returns the base URL for requesting an access token.
+	 * Returns the base URL for requesting or revoking an access token.
 	 *
 	 * Eg. https://oauth.service.com/token
 	 *
@@ -150,8 +150,11 @@ class Mollie extends AbstractProvider
 	}
 
     /**
-     * @param $accessToken
+     * Revoke a Mollie access token.
      *
+     * @param string $accessToken
+     *
+     * @return \Psr\Http\Message\ResponseInterface
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function revokeAccessToken($accessToken)
@@ -160,8 +163,11 @@ class Mollie extends AbstractProvider
     }
 
     /**
-     * @param $refreshToken
+     * Revoke a Mollie refresh token.
      *
+     * @param string $refreshToken
+     *
+     * @return \Psr\Http\Message\ResponseInterface
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function revokeRefreshToken($refreshToken)
@@ -170,9 +176,12 @@ class Mollie extends AbstractProvider
     }
 
     /**
-     * @param $type
-     * @param $token
+     * Revoke a Mollie access token or refresh token.
      *
+     * @param string $type
+     * @param string $token
+     *
+     * @return \Psr\Http\Message\ResponseInterface
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function revokeToken($type, $token)
@@ -184,6 +193,8 @@ class Mollie extends AbstractProvider
 	}
 
     /**
+     * Sends a token revocation request and returns an response instance.
+     *
      * @param array $params
      *
      * @return \Psr\Http\Message\ResponseInterface

--- a/src/Provider/Mollie.php
+++ b/src/Provider/Mollie.php
@@ -156,7 +156,7 @@ class Mollie extends AbstractProvider
      */
     public function revokeAccessToken($accessToken)
     {
-        $this->revokeToken('access_token', $accessToken);
+        return $this->revokeToken('access_token', $accessToken);
     }
 
     /**
@@ -166,7 +166,7 @@ class Mollie extends AbstractProvider
      */
     public function revokeRefreshToken($refreshToken)
     {
-        $this->revokeToken('refresh_token', $refreshToken);
+        return $this->revokeToken('refresh_token', $refreshToken);
     }
 
     /**
@@ -177,7 +177,7 @@ class Mollie extends AbstractProvider
      */
     public function revokeToken($type, $token)
     {
-        $this->getRevokeTokenResponse([
+        return $this->getRevokeTokenResponse([
             'token_type_hint' => $type,
             'token' => $token,
         ]);

--- a/src/Provider/Mollie.php
+++ b/src/Provider/Mollie.php
@@ -32,6 +32,11 @@ class Mollie extends AbstractProvider
 	 */
 	const CLIENT_ID_PREFIX = 'app_';
 
+    /**
+     * @var string HTTP method used to revoke tokens.
+     */
+    const METHOD_DELETE = 'DELETE';
+
 	/**
 	 * Shortcuts to the available Mollie scopes.
 	 *
@@ -142,6 +147,41 @@ class Mollie extends AbstractProvider
 	public function getResourceOwnerDetailsUrl (AccessToken $token)
 	{
 		return static::MOLLIE_API_URL . '/v2/organizations/me';
+	}
+
+    public function revokeAccessToken($accessToken)
+    {
+        $this->revokeToken('access_token', $accessToken);
+    }
+
+    public function revokeRefreshToken($refreshToken)
+    {
+        $this->revokeToken('refresh_token', $refreshToken);
+    }
+
+	public function revokeToken($type, $token)
+    {
+        $this->getRevokeTokenResponse([
+            'token_type_hint' => $type,
+            'token' => $token,
+        ]);
+	}
+
+    protected function getRevokeTokenResponse(array $params)
+    {
+        $query = $this->buildQueryString($params);
+        $url = $this->appendQuery(
+            $this->getBaseAccessTokenUrl([]),
+            $query
+        );
+
+        $request = $this->getAuthenticatedRequest(
+            self::METHOD_DELETE,
+            $url,
+            ''
+        );
+
+        return $this->getHttpClient()->send($request);
 	}
 
 	/**

--- a/tests/src/Provider/MollieTest.php
+++ b/tests/src/Provider/MollieTest.php
@@ -101,6 +101,21 @@ class MollieTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($token->getResourceOwnerId());
     }
 
+    public function testRevokeToken()
+    {
+        $response = m::mock(ResponseInterface::class);
+        $response->shouldReceive('getStatusCode')->andReturn(204);
+
+        $client = m::mock(ClientInterface::class);
+        $client->shouldReceive('send')->times(1)->andReturn($response);
+
+        $this->provider->setHttpClient($client);
+
+        $result = $this->provider->revokeToken('refresh_token', 'mock_refresh_token');
+
+        $this->assertNull($result);
+    }
+
     public function testExceptionThrownWhenErrorObjectReceived()
     {
         $message = uniqid();

--- a/tests/src/Provider/MollieTest.php
+++ b/tests/src/Provider/MollieTest.php
@@ -118,10 +118,10 @@ class MollieTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($result->getStatusCode(), 204);
     }
 
-    public function testRevokeRefreshToken()
+    public function testRevokeAccessToken()
     {
         $response = m::mock(ResponseInterface::class);
-        $response->shouldReceive('getBody')->andReturn('{"client_id":'.self::MOCK_CLIENT_ID.', "client_secret":'.self::MOCK_SECRET.', "redirect_uri":'.self::REDIRECT_URI.', "token_type_hint":"refresh_token":"mock_access_token"}');
+        $response->shouldReceive('getBody')->andReturn('{"client_id":'.self::MOCK_CLIENT_ID.', "client_secret":'.self::MOCK_SECRET.', "redirect_uri":'.self::REDIRECT_URI.', "token_type_hint":"access_token":"mock_access_token"}');
         $response->shouldReceive('getHeader')->andReturn(['content-type' => 'application/x-www-form-urlencoded']);
         $response->shouldReceive('getStatusCode')->andReturn(204);
 
@@ -130,7 +130,24 @@ class MollieTest extends \PHPUnit_Framework_TestCase
 
         $this->provider->setHttpClient($client);
 
-        $result = $this->provider->revokeRefreshToken('mock_access_token');
+        $result = $this->provider->revokeAccessToken('mock_access_token');
+
+        $this->assertEquals($result->getStatusCode(), 204);
+    }
+
+    public function testRevokeRefreshToken()
+    {
+        $response = m::mock(ResponseInterface::class);
+        $response->shouldReceive('getBody')->andReturn('{"client_id":'.self::MOCK_CLIENT_ID.', "client_secret":'.self::MOCK_SECRET.', "redirect_uri":'.self::REDIRECT_URI.', "token_type_hint":"refresh_token":"mock_refresh_token"}');
+        $response->shouldReceive('getHeader')->andReturn(['content-type' => 'application/x-www-form-urlencoded']);
+        $response->shouldReceive('getStatusCode')->andReturn(204);
+
+        $client = m::mock(ClientInterface::class);
+        $client->shouldReceive('send')->times(1)->andReturn($response);
+
+        $this->provider->setHttpClient($client);
+
+        $result = $this->provider->revokeRefreshToken('mock_refresh_token');
 
         $this->assertEquals($result->getStatusCode(), 204);
     }

--- a/tests/src/Provider/MollieTest.php
+++ b/tests/src/Provider/MollieTest.php
@@ -1,8 +1,6 @@
 <?php namespace Mollie\OAuth2\Client\Test\Provider;
 
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Psr7\Response;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
 use Mockery as m;
@@ -106,56 +104,35 @@ class MollieTest extends \PHPUnit_Framework_TestCase
     public function testRevokeToken()
     {
         $response = m::mock(ResponseInterface::class);
+        $response->shouldReceive('getBody')->andReturn('{"client_id":'.self::MOCK_CLIENT_ID.', "client_secret":'.self::MOCK_SECRET.', "redirect_uri":'.self::REDIRECT_URI.', "token_type_hint":"access_token":"mock_access_token"}');
+        $response->shouldReceive('getHeader')->andReturn(['content-type' => 'application/x-www-form-urlencoded']);
         $response->shouldReceive('getStatusCode')->andReturn(204);
 
         $client = m::mock(ClientInterface::class);
         $client->shouldReceive('send')->times(1)->andReturn($response);
-
-        $this->provider->setHttpClient($client);
-
-        $result = $this->provider->revokeToken('refresh_token', 'mock_refresh_token');
-
-        $this->assertNull($result);
-    }
-
-    public function testRevokeRefreshToken()
-    {
-        $response = m::mock(ResponseInterface::class);
-        $response->shouldReceive('getStatusCode')->andReturn(204);
-
-        $client = m::mock(ClientInterface::class);
-        $client->shouldReceive('send')->times(1)->andReturn($response);
-
-        $this->provider->setHttpClient($client);
-
-        $result = $this->provider->revokeRefreshToken('mock_refresh_token');
-
-        $this->assertNull($result);
-    }
-
-    public function testRevokeAccessToken()
-    {
-        $response = m::mock(ResponseInterface::class);
-        $response->shouldReceive('getStatusCode')->andReturn(204);
-
-        $client = m::mock(ClientInterface::class);
-        $request = new Request(
-            'delete',
-            '/oauth2/tokens?token_type_hint=access_token&token=mock_access_token',
-            [
-                'client_id' => 'app_mock_client_id',
-                'client_secret' => 'mock_secret',
-                'Host' => 'api.mollie.com',
-            ]
-        ); // TODO use $this->mockHttpClient instead
-
-        $client->shouldReceive('send')->with($request)->times(1)->andReturn($response);
 
         $this->provider->setHttpClient($client);
 
         $result = $this->provider->revokeAccessToken('mock_access_token');
 
-        $this->assertNull($result);
+        $this->assertEquals($result->getStatusCode(), 204);
+    }
+
+    public function testRevokeRefreshToken()
+    {
+        $response = m::mock(ResponseInterface::class);
+        $response->shouldReceive('getBody')->andReturn('{"client_id":'.self::MOCK_CLIENT_ID.', "client_secret":'.self::MOCK_SECRET.', "redirect_uri":'.self::REDIRECT_URI.', "token_type_hint":"refresh_token":"mock_access_token"}');
+        $response->shouldReceive('getHeader')->andReturn(['content-type' => 'application/x-www-form-urlencoded']);
+        $response->shouldReceive('getStatusCode')->andReturn(204);
+
+        $client = m::mock(ClientInterface::class);
+        $client->shouldReceive('send')->times(1)->andReturn($response);
+
+        $this->provider->setHttpClient($client);
+
+        $result = $this->provider->revokeRefreshToken('mock_access_token');
+
+        $this->assertEquals($result->getStatusCode(), 204);
     }
 
     public function testExceptionThrownWhenErrorObjectReceived()
@@ -285,51 +262,5 @@ class MollieTest extends \PHPUnit_Framework_TestCase
 
         list($url) = explode('?', $this->provider->getAuthorizationUrl());
         $this->assertEquals('https://www.mollie.nl/oauth2/authorize', $url);
-    }
-
-    protected function mockHttpClient(Request $expectedRequest, Response $response)
-    {
-        $client= $this->createMock(ClientInterface::class);
-
-        $client
-            ->expects($this->once())
-            ->method('send')
-            ->with($this->isInstanceOf(Request::class))
-            ->willReturnCallback(function (Request $request) use ($expectedRequest, $response) {
-                $this->assertEquals($expectedRequest->getMethod(), $request->getMethod(), "HTTP method must be identical");
-
-                $this->assertEquals(
-                    $expectedRequest->getUri()->getPath(),
-                    $request->getUri()->getPath(),
-                    "URI path must be identical"
-                );
-
-                $this->assertEquals(
-                    $expectedRequest->getUri()->getQuery(),
-                    $request->getUri()->getQuery(),
-                    'Query string parameters must be identical'
-                );
-
-                $requestBody = $request->getBody()->getContents();
-                $expectedBody = $expectedRequest->getBody()->getContents();
-
-                if (strlen($expectedBody) > 0 && strlen($requestBody) > 0) {
-                    $this->assertJsonStringEqualsJsonString(
-                        $expectedBody,
-                        $requestBody,
-                        "HTTP body must be identical"
-                    );
-                }
-
-                $this->assertArraySubset(
-                    $expectedRequest->getHeaders(),
-                    $request->getHeaders(),
-                    'Expected headers incomplete'
-                );
-
-                return $response;
-            });
-
-        return $client;
     }
 }


### PR DESCRIPTION
Solves #20.

Adds:

- `revokeToken(string $type, string $token)`
- `revokeAccessToken(string $accessToken)`
- `revokeRefreshToken(string $refreshToken)`

Can someone at Mollie with a good understanding of Mollie Connect review this PR? I'm a bit unsure about the request parameter formats and I don't have an integration setup at hand.