### PR TITLE
Temporarily fixate league version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
   ],
   "require": {
     "php": "^7.4|^8.0",
-    "league/oauth2-client": "^2.7"
+    "league/oauth2-client": "^2.7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.6|^10.0",


### PR DESCRIPTION
Temporarily fixate the league package to `v2.7.x`, as `2.8.0` is causing issues. Will keep an eye out for fixes there or see if we can help patch it after the holidays.

https://github.com/thephpleague/oauth2-client/issues/1052
https://github.com/thephpleague/oauth2-client/issues/1051
